### PR TITLE
Prevent CommunicationsHost from taking 100% of a core

### DIFF
--- a/Source/Private/ThirdParty/NetImgui/Private/NetImgui_Client.cpp
+++ b/Source/Private/ThirdParty/NetImgui/Private/NetImgui_Client.cpp
@@ -255,7 +255,11 @@ void CommunicationsHost(void* pClientVoid)
 				bConnected	= Communications_Outgoing(*pClient) && Communications_Incoming(*pClient);
 			}
 			pClient->KillSocketComs();
-		}			
+		}
+		else
+		{
+			std::this_thread::sleep_for(std::chrono::milliseconds(1));
+		}
 	}
 
 	pClient->KillSocketAll();


### PR DESCRIPTION
As discussed in https://github.com/sammyfreg/UnrealNetImgui/issues/2