### PR TITLE
Added specific config for dedicated servers

### DIFF
--- a/NetImguiServer/netImgui.cfg
+++ b/NetImguiServer/netImgui.cfg
@@ -1,18 +1,24 @@
 {
- "Configs": [
-  {
-   "Auto": true,
-   "HostPort": 8889,
-   "Hostname": "localhost",
-   "Name": "UE4 Game"
-  },
-  {
-   "Auto": true,
-   "HostPort": 8890,
-   "Hostname": "localhost",
-   "Name": "UE4 Editor"
-  }
- ],
+  "Configs": [
+    {
+      "Auto": true,
+      "HostPort": 8889,
+      "Hostname": "localhost",
+      "Name": "UE4 Game"
+    },
+    {
+      "Auto": true,
+      "HostPort": 8890,
+      "Hostname": "localhost",
+      "Name": "UE4 Editor"
+    },
+    {
+      "Auto": true,
+      "HostPort": 8891,
+      "Hostname": "localhost",
+      "Name": "UE4 Dedicated Server"
+    }
+  ],
  "Note": "netImgui Server's list of Clients (Using JSON format).",
  "ServerPort": 8888,
  "Version": 1

--- a/Source/NetImgui.Build.cs
+++ b/Source/NetImgui.Build.cs
@@ -65,6 +65,10 @@ public class NetImgui : ModuleRules
 		// NetImgui Server will try to find running editor client on this port and connect to them
 		string kEditorListenPort	= "(NetImgui::kDefaultClientPort+1)";
 
+		// Com Port used by Dedicated Server exe to wait for a connection from netImgui Server (8891 by default)
+		// NetImgui Server will try to find running dedicaed server client on this port and connect to them
+		string kDedicatedServerListenPort = "(NetImgui::kDefaultClientPort+2)";
+
 		// Developer modules are automatically loaded only in editor builds but can be stripped out from other builds.
 		// Enable runtime loader, if you want this module to be automatically loaded in runtime builds (monolithic).
 		bool bEnableRuntimeLoader = true;
@@ -87,7 +91,8 @@ public class NetImgui : ModuleRules
 		PublicDefinitions.Add(string.Format("NETIMGUI_DEMO_ACTOR_ENABLED={0}", bDemoActor_Enabled ? 1 : 0));		
 		PublicDefinitions.Add("NETIMGUI_LISTENPORT_GAME=" + kGameListenPort);
 		PublicDefinitions.Add("NETIMGUI_LISTENPORT_EDITOR=" + kEditorListenPort);
-
+		PublicDefinitions.Add("NETIMGUI_LISTENPORT_DEDICATED_SERVER=" + kDedicatedServerListenPort);
+		
 		PrivateDefinitions.Add("NETIMGUI_WINSOCKET_ENABLED=0");      // Using Unreal sockets, no need for built-in sockets
 		PrivateDefinitions.Add("NETIMGUI_POSIX_SOCKETS_ENABLED=0");  // Using Unreal sockets, no need for built-in sockets
 		PrivateDefinitions.Add(string.Format("RUNTIME_LOADER_ENABLED={0}", bEnableRuntimeLoader ? 1 : 0));

--- a/Source/Private/NetImguiModule.cpp
+++ b/Source/Private/NetImguiModule.cpp
@@ -20,6 +20,24 @@
 #define LOCTEXT_NAMESPACE "FNetImguiModule"
 IMPLEMENT_MODULE(FNetImguiModule, NetImgui)
 
+#if NETIMGUI_ENABLED
+uint32_t GetClientPort()
+{
+	if (IsRunningDedicatedServer())
+	{
+		return NETIMGUI_LISTENPORT_DEDICATED_SERVER;
+	}
+	else if (FApp::IsGame())
+	{
+		return NETIMGUI_LISTENPORT_GAME;
+	}
+	else
+	{
+		return NETIMGUI_LISTENPORT_EDITOR;
+	}
+}
+#endif
+
 void FNetImguiModule::StartupModule()
 {
 #if NETIMGUI_ENABLED
@@ -55,7 +73,7 @@ void FNetImguiModule::StartupModule()
 	// Note:	The default behaviour is for the Game Client to wait for connection from the NetImgui Server.
 	//			It is possible to connect directly to the NetImgui Server insted, using 'NetImgui::ConnectToApp'
 	FString sessionName = FString::Format(TEXT("{0}-{1}"), { FApp::GetProjectName(), FPlatformProcess::ComputerName() });
-	NetImgui::ConnectFromApp(TCHAR_TO_ANSI(sessionName.GetCharArray().GetData()), FApp::IsGame() ? NETIMGUI_LISTENPORT_GAME : NETIMGUI_LISTENPORT_EDITOR);
+	NetImgui::ConnectFromApp(TCHAR_TO_ANSI(sessionName.GetCharArray().GetData()), GetClientPort());
 	//---------------------------------------------------------------------------------------------
 
 	FCoreDelegates::OnEndFrame.AddRaw(this, &FNetImguiModule::Update);


### PR DESCRIPTION
There are use cases for a third config for dedicated servers. It is possible to run a client, a server *and* the editor on the same machine. It's also pretty common to have the game and the server running separately. This third config supports these use cases.