### PR TITLE
Support hot-reloading by caching ImGui context in initially loaded DLL

### DIFF
--- a/Source/Private/NetImguiModule.cpp
+++ b/Source/Private/NetImguiModule.cpp
@@ -42,8 +42,9 @@ void FNetImguiModule::StartupModule()
 {
 #if NETIMGUI_ENABLED
 	NetImgui::Startup();
-		
-	ImGui::SetCurrentContext(ImGui::CreateContext());
+	
+	CreatedContext = ImGui::CreateContext();
+	ImGui::SetCurrentContext(CreatedContext);
 	ImGuiIO& io = ImGui::GetIO();
 	io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
 
@@ -87,7 +88,7 @@ void FNetImguiModule::ShutdownModule()
 		NetImgui::EndFrame();
 	NetImgui::Shutdown(true);
 
-	ImGui::DestroyContext(ImGui::GetCurrentContext());
+	ImGui::DestroyContext(CreatedContext);
 #endif
 }
 

--- a/Source/Public/NetImguiModule.h
+++ b/Source/Public/NetImguiModule.h
@@ -57,7 +57,23 @@ public:
 		return false;
 	#endif
 	}
-	
+
+	// This is required for hot-reload support
+	static inline void EnsureImGuiContext()
+	{
+#if NETIMGUI_ENABLED
+		// Is the ImGui context set (it will not be for freshly reloaded DLLs)?
+		if (IsAvailable() && ImGui::GetCurrentContext() == nullptr)
+		{
+			// Get the context from the original DLL
+			ImGuiContext* ModuleContext = FNetImguiModule::Get().CreatedContext;
+
+			// Set it in this hot-reloaded DLL
+			ImGui::SetCurrentContext(ModuleContext);
+		}
+#endif
+	}
+
 	/**
 	 * Replace the default Font
 	 */
@@ -102,6 +118,11 @@ public:
 	virtual void StartupModule() override;
 	virtual void ShutdownModule() override;
 	void Update();
+
+private:
+#if NETIMGUI_ENABLED
+	ImGuiContext* CreatedContext = nullptr;
+#endif
 };
 
 #if NETIMGUI_ENABLED


### PR DESCRIPTION
As it stands UnrealNetImgui is not hot-reload friendly. UE4 supports the hot-reloading of code by building and loading additional instances of DLLs. If the user rebuilds while NetImGui is running, the first call to ImGui:: methods will crash as GImGui is null in that DLL.

This change supports that workflow by providing a hook that can be called to ensure the ImGui context is correct for hot-reloaded DLLs.

To fully support this the game project must call into this hook at an appropriate time. One way to achieve this is by creating a UEngineSubsystem that calls the FNetImguiModule hook as follows.

```
// Ensure that hot-reloaded DLLs have their ImGui context set
UCLASS()
class UNetImGuiContextRefreshSubsystem : public UEngineSubsystem
{
	GENERATED_BODY()

protected:
	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
	virtual void Deinitialize() override;
};

...

void UNetImGuiContextRefreshSubsystem::Initialize(FSubsystemCollectionBase& Collection)
{
#if NETIMGUI_ENABLED
	FNetImguiModule::EnsureImGuiContext();
#endif // NETIMGUI_ENABLED
}

void UNetImGuiContextRefreshSubsystem::Deinitialize()
{
}
```