### PR TITLE
Define FNetImguiModel::kModuleName for Clang compiler

### DIFF
--- a/Source/Private/NetImguiModule.cpp
+++ b/Source/Private/NetImguiModule.cpp
@@ -20,6 +20,9 @@
 #define LOCTEXT_NAMESPACE "FNetImguiModule"
 IMPLEMENT_MODULE(FNetImguiModule, NetImgui)
 
+// define the symbol for Clang compiler
+constexpr char FNetImguiModule::kModuleName[];
+
 #if NETIMGUI_ENABLED
 uint32_t GetListeningPort()
 {


### PR DESCRIPTION
Fix for build failures on Linux:

```
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
ld.lld: error: undefined symbol: FNetImguiModule::kModuleName
```