### PR TITLE
Build fix for XSX

### DIFF
--- a/Source/NetImgui.Build.cs
+++ b/Source/NetImgui.Build.cs
@@ -190,5 +190,10 @@ public class NetImgui : ModuleRules
 		PrivateDefinitions.Add("NETIMGUI_WINSOCKET_ENABLED=0");      // Using Unreal sockets, no need for built-in sockets
 		PrivateDefinitions.Add("NETIMGUI_POSIX_SOCKETS_ENABLED=0");  // Using Unreal sockets, no need for built-in sockets
 		PrivateDefinitions.Add(string.Format("RUNTIME_LOADER_ENABLED={0}", bEnableRuntimeLoader ? 1 : 0));
+
+		if (Target.Platform.Equals(UnrealTargetPlatform.XSX))
+		{
+			PublicDefinitions.Add("IMGUI_DISABLE_WIN32_FUNCTIONS=1");
+		}
 	}
 }


### PR DESCRIPTION
This is a fix we required locally for our XSX client builds.

Notes from the person who contributed the fix are "Don't let imgui build platform native stuff on xbox.
Without this define imgui will detect _WIN32 and try to compile platform handlers for clipboard and similar functionality as if the platform is windows. This code doesn't compile for xbox so we inject a define for XSX builds that compiled out this code."